### PR TITLE
fixed goals layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -58,7 +58,7 @@
           </li>
         </ul>
       </div>
-    </div>
+
 
     <div class="row">
       <div ng-if="showGoalTracker">
@@ -68,7 +68,7 @@
       <div ng-include="'partials/jobTruncate.html'"></div>
       <div ng-include="'partials/jobDetail.html'"></div>
     </div>
-
+    </div>
   </div>
 
 


### PR DESCRIPTION
Fixed the goals layout so it's not on the left edge of the window. The problem was that the goals html was outside of the container div that Skeleton uses.