### PR TITLE
added pointer cursor on hover of clickable items

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -15,6 +15,9 @@ h1 {
 	text-shadow: 1px 1px 1px #D3D3D3;
 
 }
+a:hover, td.ng-binding {
+	cursor: pointer;
+}
 
 .columns {
 	display: inline-block;


### PR DESCRIPTION
I received feedback from a conference that users can't initially tell when an item like a job search result is actually clickable. I added a hover styling for links and elements with the class "ng-binding" so that the user will see the pointer hand when hovering over clickable elements.
